### PR TITLE
remove red color from latest file date

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -147,10 +147,6 @@
 	display: inline-block;
 }
 
-.latestfile {
-	color: red;
-}
-
 #grouplist {
         /*z-index: 100;*/
 }


### PR DESCRIPTION
This is quite strange – we do this nowhere else in ownCloud. And red is really a warning color.

@Fmstrat If you want to highlight the date of the note, use the same algorithm as we use in Files: The date of new files is darker, the date of older ones gets lighter the older they are: https://github.com/owncloud/core/blob/master/apps/files/js/filelist.js#L800-L824