### PR TITLE
Fix bug when using mode : "Database and Folder"

### DIFF
--- a/lib/backend.php
+++ b/lib/backend.php
@@ -185,7 +185,8 @@ class Backend {
 			}
 			// Synchronize files to the database
 			$filearr = array();
-			if ($listing = \OC\Files\Storage\Local::opendir($FOLDER)) {
+			$folderview = new \OC\Files\Storage\Local(array("datadir" => $FOLDER));
+			if ($listing = $folderview->opendir('.')) {
 				if (!$listing) {
 					echo "ERROR: Error listing directory.";
 					exit;


### PR DESCRIPTION
Using mode : "Database and Folder" resulted in an error:
message":{"Exception":"Error","Message":"Using $this when not in object context","Code":0,"Trace":[{"file":"\/var\/www\/html\/nextcloud\/apps\/ownnote\/lib\/backend.php","line":188,"function":"opendir","class":"OC\\Files\\Storage\\Local","type":"::","args":["Notes"]}
This is fixing it. The problem already occurred in Nextcloud 13, see #351 
User @BFMVFreddy confirmed that the fix worked, and it works for me too.