### PR TITLE
Up owncloud max-version to 10.0.10

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <requiremin>7.0.3</requiremin>
     <dependencies>
         <lib>curl</lib>
-        <owncloud min-version="7.0.3" max-version="9.2" />
+        <owncloud min-version="7.0.3" max-version="10.0.10" />
         <nextcloud min-version="9.1" max-version="16" />
     </dependencies>
 </info>


### PR DESCRIPTION
Ownnote _does_ work with owncloud 10.0.10, but complains if you try to use it above 9.2 due to max-version declaration.